### PR TITLE
[SHIP] Upgrade log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-bom</artifactId>
-				<version>2.11.0</version>
+				<version>2.17.1</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>


### PR DESCRIPTION
This PR upgrades log4j libraries to the latest patched version. 
Plus it is meant to fix builds of [sc-sqs-exporter](https://github.com/soundcloud/sc-sqs-exporter) which are failing due to the old log4j versions can't be found in the maven repo.
