### PR TITLE
Increase the range of allowed maven versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
 							<fail>true</fail>
 							<rules>
 								<requireMavenVersion>
-									<version>[3.0,3.9)</version>
+									<version>[3.0,4.0)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>[1.8,)</version>


### PR DESCRIPTION
sqs exporter build started to fail with the following error:
```
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
Detected Maven Version: 3.9.0 is not in the allowed range [3.0,3.9).
```
This PR aims to fix the build by allowing Maven version 3.9.0 